### PR TITLE
Changes to version and candidate in get snapshot command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ cp output/korn /usr/local/bin/
 
 3. **Create a release**:
    ```bash
-   korn create release --app operator-1-0 --environment staging
+   # Get latest candidate snapshot
+   SNAPSHOT=$(korn get snapshot --app operator-1-0 --candidate | tail -n 1 | awk '{print $1}')
+
+   # Create release with snapshot
+   korn create release --app operator-1-0 --environment staging --snapshot $SNAPSHOT
    ```
 
 ## Essential Commands
@@ -63,7 +67,7 @@ cp output/korn /usr/local/bin/
 |---------|---------|---------|
 | `get application` | List applications with types | `korn get application` |
 | `get snapshot --candidate` | Get latest valid snapshot | `korn get snapshot --app operator-1-0 --candidate` |
-| `create release` | Create new release | `korn create release --app operator-1-0 --environment staging` |
+| `create release` | Create new release | `korn create release --app operator-1-0 --environment staging --snapshot <snapshot-name>` |
 | `waitfor release` | Wait for completion | `korn waitfor release <release-name>` |
 
 For complete command reference, see [Commands Documentation](docs/commands.md).
@@ -97,14 +101,15 @@ korn get application --namespace my-operator-namespace
 korn get application
 korn get component --app operator-1-0
 
-# 2. Check latest candidate
-korn get snapshot --app operator-1-0 --candidate
+# 2. Check latest candidate and capture snapshot name
+SNAPSHOT=$(korn get snapshot --app operator-1-0 --candidate | tail -n 1 | awk '{print $1}')
+echo "Using snapshot: $SNAPSHOT"
 
-# 3. Create staging release
-korn create release --app operator-1-0 --environment staging
+# 3. Create staging release with captured snapshot
+korn create release --app operator-1-0 --environment staging --snapshot $SNAPSHOT
 
-# 4. Promote to production
-korn create release --app operator-1-0 --environment production
+# 4. Promote to production using same snapshot
+korn create release --app operator-1-0 --environment production --snapshot $SNAPSHOT
 ```
 
 ## Getting Help

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,8 +80,8 @@ korn get application
 korn get component --app operator-1-0
 
 # Release workflow
-korn get snapshot --app operator-1-0 --candidate
-korn create release --app operator-1-0 --environment staging
+SNAPSHOT=$(korn get snapshot --app operator-1-0 --candidate | tail -n 1 | awk '{print $1}')
+korn create release --app operator-1-0 --environment staging --snapshot $SNAPSHOT
 
 # Debugging
 korn get snapshot --app operator-1-0

--- a/internal/konflux/types.go
+++ b/internal/konflux/types.go
@@ -25,6 +25,7 @@ type Korn struct {
 	PodClient       internal.ImageClient
 	GitClient       internal.GitCommitVersioner
 	DynamicClient   dynamic.Interface
+	Candidate       bool
 }
 
 type ReleaseNote struct {


### PR DESCRIPTION
This PR changes the `--version` behavior so that:
* It can be used to filter all candidate snapshots for a given version with the `--candidate` command
* Returns all the snapshots that match the given version
* Extend unit tests to cover these scenarios
* Update documentation to ensure that the snapshot value from `korn get snapshot` is used in the `korn create release` command.